### PR TITLE
Purchase grocery

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,13 +16,15 @@
         "express": "^4.18.2",
         "jsonwebtoken": "^9.0.2",
         "nodemon": "^3.1.0",
-        "prisma": "^5.10.2"
+        "prisma": "^5.10.2",
+        "uuid": "^9.0.1"
       },
       "devDependencies": {
         "@types/bcryptjs": "^2.4.6",
         "@types/cors": "^2.8.17",
         "@types/express": "^4.17.21",
         "@types/jsonwebtoken": "^9.0.6",
+        "@types/uuid": "^9.0.8",
         "ts-node-dev": "^2.0.0",
         "typescript": "^5.3.3"
       }
@@ -276,6 +278,12 @@
       "version": "0.0.30",
       "resolved": "https://registry.npmjs.org/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz",
       "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==",
+      "dev": true
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
+      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
       "dev": true
     },
     "node_modules/abbrev": {
@@ -1787,6 +1795,18 @@
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/package.json
+++ b/package.json
@@ -19,13 +19,15 @@
     "express": "^4.18.2",
     "jsonwebtoken": "^9.0.2",
     "nodemon": "^3.1.0",
-    "prisma": "^5.10.2"
+    "prisma": "^5.10.2",
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@types/bcryptjs": "^2.4.6",
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
     "@types/jsonwebtoken": "^9.0.6",
+    "@types/uuid": "^9.0.8",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.3.3"
   }

--- a/prisma/migrations/20240229074631_transaction_history_model/migration.sql
+++ b/prisma/migrations/20240229074631_transaction_history_model/migration.sql
@@ -1,0 +1,17 @@
+-- AlterTable
+ALTER TABLE "GroceryListBooked" ALTER COLUMN "transactionId" SET DATA TYPE TEXT;
+
+-- CreateTable
+CREATE TABLE "TransactionHistory" (
+    "id" SERIAL NOT NULL,
+    "transactionId" TEXT NOT NULL,
+    "totalAmount" INTEGER NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updateAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "TransactionHistory_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "TransactionHistory" ADD CONSTRAINT "TransactionHistory_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20240229090906_amount_int_to_decimal/migration.sql
+++ b/prisma/migrations/20240229090906_amount_int_to_decimal/migration.sql
@@ -1,0 +1,15 @@
+/*
+  Warnings:
+
+  - You are about to alter the column `groceryPrice` on the `GroceryList` table. The data in that column could be lost. The data in that column will be cast from `Integer` to `Decimal(8,2)`.
+  - You are about to alter the column `groceryPrice` on the `GroceryListBooked` table. The data in that column could be lost. The data in that column will be cast from `Integer` to `Decimal(8,2)`.
+
+*/
+-- AlterTable
+ALTER TABLE "GroceryList" ALTER COLUMN "groceryPrice" SET DATA TYPE DECIMAL(8,2);
+
+-- AlterTable
+ALTER TABLE "GroceryListBooked" ALTER COLUMN "groceryPrice" SET DATA TYPE DECIMAL(8,2);
+
+-- AlterTable
+ALTER TABLE "TransactionHistory" ALTER COLUMN "totalAmount" SET DATA TYPE DECIMAL(16,2);

--- a/prisma/migrations/20240229091022_grocery_stock_count_int_to_decimal/migration.sql
+++ b/prisma/migrations/20240229091022_grocery_stock_count_int_to_decimal/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - You are about to alter the column `groceryStockCount` on the `GroceryList` table. The data in that column could be lost. The data in that column will be cast from `Integer` to `Decimal(8,2)`.
+
+*/
+-- AlterTable
+ALTER TABLE "GroceryList" ALTER COLUMN "groceryStockCount" SET DEFAULT 0.00,
+ALTER COLUMN "groceryStockCount" SET DATA TYPE DECIMAL(8,2);

--- a/prisma/migrations/20240229092311_additional_col_for_transaction_history_grocery_list_booked/migration.sql
+++ b/prisma/migrations/20240229092311_additional_col_for_transaction_history_grocery_list_booked/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - Added the required column `isPurchaseConfirmed` to the `GroceryListBooked` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `transactionStatus` to the `GroceryListBooked` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `transactionStatus` to the `TransactionHistory` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "GroceryListBooked" ADD COLUMN     "isPurchaseConfirmed" BOOLEAN NOT NULL,
+ADD COLUMN     "transactionStatus" TEXT NOT NULL;
+
+-- AlterTable
+ALTER TABLE "TransactionHistory" ADD COLUMN     "transactionStatus" TEXT NOT NULL;

--- a/prisma/migrations/20240229095728_col_reframe_grocery_list_booked/migration.sql
+++ b/prisma/migrations/20240229095728_col_reframe_grocery_list_booked/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `groceryQuantity` on the `GroceryListBooked` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "GroceryListBooked" DROP COLUMN "groceryQuantity",
+ADD COLUMN     "purchaseQuantity" INTEGER NOT NULL DEFAULT 0,
+ALTER COLUMN "isPurchaseConfirmed" SET DEFAULT false,
+ALTER COLUMN "transactionStatus" SET DEFAULT 'Approved';

--- a/prisma/migrations/20240229155904_added_col_grocery_price_by_quantity_grocery_list_booked/migration.sql
+++ b/prisma/migrations/20240229155904_added_col_grocery_price_by_quantity_grocery_list_booked/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `groceryPriceByQuantity` to the `GroceryListBooked` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "GroceryListBooked" ADD COLUMN     "groceryPriceByQuantity" DECIMAL(8,2) NOT NULL;

--- a/prisma/migrations/20240229162833_type_change_purchase_quantity_grocery_list_booked/migration.sql
+++ b/prisma/migrations/20240229162833_type_change_purchase_quantity_grocery_list_booked/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - You are about to alter the column `purchaseQuantity` on the `GroceryListBooked` table. The data in that column could be lost. The data in that column will be cast from `Integer` to `Decimal(8,2)`.
+
+*/
+-- AlterTable
+ALTER TABLE "GroceryListBooked" ALTER COLUMN "purchaseQuantity" DROP DEFAULT,
+ALTER COLUMN "purchaseQuantity" SET DATA TYPE DECIMAL(8,2);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,31 +20,46 @@ model User {
   password   String?
   isAdmin    Boolean @default(false)
   adminKey   String?
+  groceryBookedList GroceryListBooked[]
+  transactionHistory TransactionHistory[]
   createdAt  DateTime @default(now())
   updateAt   DateTime @default(now()) @updatedAt
-  groceryBookedList GroceryListBooked[]
 }
 
 model GroceryList {
   id                 Int @id @default(autoincrement())
   groceryName        String
-  groceryPrice       Int
+  groceryPrice       Decimal  @db.Decimal(8,2)
   groceryType        String?
-  groceryStockCount  Int @default(0)
+  groceryStockCount  Decimal  @db.Decimal(8,2) @default(0.00)
   createdAt          DateTime @default(now())
   updateAt           DateTime @default(now()) @updatedAt
 }
 
 model GroceryListBooked {
-  id               Int @id @default(autoincrement())
-  groceryId        Int
-  groceryName      String
-  groceryPrice     Int
-  groceryType      String?
-  groceryQuantity  Int @default(0)
-  transactionId    Int
-  createdAt        DateTime @default(now())
-  updateAt         DateTime @default(now()) @updatedAt
-  userId           Int
-  user             User @relation(fields: [userId], references: [id])
+  id                     Int @id @default(autoincrement())
+  groceryId              Int
+  groceryName            String
+  groceryPrice           Decimal  @db.Decimal(8,2)
+  groceryType            String?
+  purchaseQuantity       Decimal  @db.Decimal(8,2)
+  groceryPriceByQuantity Decimal  @db.Decimal(8,2)
+  transactionId          String
+  isPurchaseConfirmed    Boolean @default(false)
+  transactionStatus      String @default("Approved")
+  userId                 Int
+  user                   User @relation(fields: [userId], references: [id])
+  createdAt              DateTime @default(now())
+  updateAt               DateTime @default(now()) @updatedAt
+}
+
+model TransactionHistory {
+  id                Int @id @default(autoincrement())
+  transactionId     String
+  transactionStatus String
+  totalAmount       Decimal  @db.Decimal(16,2)
+  userId            Int
+  user              User @relation(fields: [userId], references: [id])
+  createdAt         DateTime @default(now())
+  updateAt          DateTime @default(now()) @updatedAt
 }

--- a/routes/Grocery/index.ts
+++ b/routes/Grocery/index.ts
@@ -6,18 +6,40 @@ import {
   updateGroceryController,
   deleteGroceryController,
   createGroceryController,
+  purchaseGroceryController,
+  confirmPurchaseGroceryController,
+  updatePaymentController,
+  deleteController,
+  insertManyController,
+  reduceGroceries,
 } from "../../controllers/groceryController";
 import checkAdminMiddleware from "../../middleware/checkAdminMiddleware";
 import authMiddleware from "../../middleware/authMiddleware";
 
 const router = express.Router();
 
+// router.delete("/deleteAll", deleteController); // For testing purposes, to be removed
+// router.post("/insert-grocery", insertManyController); // For testing purposes, to be removed
+
 /* User Routes */
+
 router.use(authMiddleware);
 
 router.get("/list", listGroceriesController);
 
 router.get("/", groceryDetailsController);
+
+// Purchase Controller is to create a purchase order
+// and returns the order with transactionId
+// Post controller, reduce the groceries quantity by previous purchase order
+router.post("/purchase-grocery", purchaseGroceryController, reduceGroceries);
+
+// Confirms the Payment and Initiate the Payment
+router.post("/confirm-purchaseGrocery", confirmPurchaseGroceryController);
+
+// Based on Payment Status update Payment status of Grocery Booked list
+// and create the Transaction Record
+router.post("/updatePayment", updatePaymentController);
 
 /* Admin Only Routes */
 

--- a/routes/Grocery/index.ts
+++ b/routes/Grocery/index.ts
@@ -39,7 +39,7 @@ router.post("/confirm-purchaseGrocery", confirmPurchaseGroceryController);
 
 // Based on Payment Status update Payment status of Grocery Booked list
 // and create the Transaction Record
-router.post("/updatePayment", updatePaymentController);
+router.post("/updatePayment", updatePaymentController); // Can be acheived, if Payment gateway intergrated
 
 /* Admin Only Routes */
 

--- a/services/HelperFunctions/createUUID.ts
+++ b/services/HelperFunctions/createUUID.ts
@@ -1,0 +1,10 @@
+import { v4 as uuidv4 } from "uuid";
+
+export const createUUID = async (): Promise<string> => {
+  try {
+    const uuid = await uuidv4();
+    return uuid;
+  } catch (error: any) {
+    return error.message || error.stack || error;
+  }
+};

--- a/services/HelperFunctions/findRecord.ts
+++ b/services/HelperFunctions/findRecord.ts
@@ -11,6 +11,8 @@ const findRecordById = async <T extends RecordDetails>(
   let details;
   switch (modelName) {
     case "groceryList":
+      console.log(searchId);
+
       details = await prisma.groceryList.findUnique({
         where: { id: +searchId },
         select: {
@@ -21,6 +23,8 @@ const findRecordById = async <T extends RecordDetails>(
           groceryStockCount: true,
         },
       });
+      console.log(details);
+
       break;
     case "user":
       details = await prisma.user.findUnique({
@@ -33,6 +37,7 @@ const findRecordById = async <T extends RecordDetails>(
           isAdmin: true,
         },
       });
+
       break;
     case "user":
       details = await prisma.user.findUnique({

--- a/types/index.ts
+++ b/types/index.ts
@@ -38,3 +38,24 @@ export interface userTokenInterface extends JwtPayload {
   isAdmin: boolean;
   adminKey?: string;
 }
+
+export type OrderTransIDMappedItem = {
+  groceryId: number;
+  groceryName: string;
+  groceryPrice: number;
+  groceryType?: string;
+  purchaseQuantity: number;
+  groceryPriceByQuantity: number;
+  transactionId: string;
+  userId: number;
+};
+
+export type OrderItem = {
+  groceryId: number;
+  groceryName: string;
+  groceryPrice: number;
+  groceryType?: string;
+  purchaseQuantity: number;
+  transactionId: string;
+  userId: number;
+};


### PR DESCRIPTION
### **Purchase grocery**

This feature creates a Purchase Order, stores the purchase order as pending, and confirms only after purchase by Payment

**Create a Purchase Order**

_Route - /purchase-grocery_
- The User can add their cart with a single grocery item or multiple and add the quantity of each item.
- This will store the order as a pending order and return a unique transactionId for either single or bulk purchase.
- After the order is created, based on the Item selected and quantity picked, the Inventory stock limit will also be reduced.

**Confirm Pending Order**

_Route - /confirm-purchaseGrocery_
- The User wants to confirm their order by paying the total amount as per their order.
- After Payment, the Order will be marked as Purchased.

> Currently, from Postman, the API will be hit with transactionId and total Amount, if the Frontend & Payment Gateway are Integrated, we can automate this. Since the motive of this route is to generate a Payment Page URL only.
And from the Payment Gateway, they want to redirect the User to /updatePayment server route and here we can update the Grocery Purchased according to the Payment Status.